### PR TITLE
Scott's suggested mods

### DIFF
--- a/particles/Services/SLANDLESServices.recipes
+++ b/particles/Services/SLANDLESServices.recipes
@@ -1,4 +1,2 @@
-import 'SLANDLESTfjs.recipes'
 import 'SLANDLESMl5.recipes'
 import 'SLANDLESServiceTest.recipes'
-

--- a/particles/Services/particles/js/MobileNet.js
+++ b/particles/Services/particles/js/MobileNet.js
@@ -45,7 +45,7 @@ defineParticle(({DomParticle, log, html, resolver}) => {
       response = response || {label: '<working>', probability: '<working>'};
       return {
         label: response.className,
-        probability: response.probability.toFixed(4),
+        probability: response.probability,
         imageUrl: url
       };
     }

--- a/src/platform/tf-node.ts
+++ b/src/platform/tf-node.ts
@@ -10,4 +10,5 @@
 
 import * as tf from '@tensorflow/tfjs-node';
 export const requireTf = async () => tf;
+export {tf};
 

--- a/src/platform/tf-web.ts
+++ b/src/platform/tf-web.ts
@@ -9,14 +9,18 @@
  */
 
 import {dynamicScript} from './dynamic-script-web.js';
+import * as tf from '../../node_modules/@tensorflow/tfjs-core/dist/tf-core.js';
 
 const TF_VERSION = '1.1.2';
 
 /** Dynamically loads and returns the `tfjs` module. */
 export const requireTf = async () => {
-  if (!window['tf']) {
-    await dynamicScript(`https://unpkg.com/@tensorflow/tfjs@${TF_VERSION}/dist/tf.min.js?module`);
+
+  // Assume tf.data is not required for most dependencies
+  if (!window['tf'] || !window['tf']['version_core'] || !window['tf']['version_layers'] || !window['tf']['version_converter']) {
+    await dynamicScript(`https://unpkg.com/@tensorflow/tfjs@${TF_VERSION}/dist/tf.min.js`);
   }
   return window['tf'];
 };
 
+export {tf};

--- a/src/platform/tf-web.ts
+++ b/src/platform/tf-web.ts
@@ -9,18 +9,14 @@
  */
 
 import {dynamicScript} from './dynamic-script-web.js';
-import * as tf from '../../node_modules/@tensorflow/tfjs-core/dist/tf-core.js';
 
 const TF_VERSION = '1.1.2';
 
 /** Dynamically loads and returns the `tfjs` module. */
 export const requireTf = async () => {
-
   // Assume tf.data is not required for most dependencies
-  if (!window['tf'] || !window['tf']['version_core'] || !window['tf']['version_layers'] || !window['tf']['version_converter']) {
+  if (!window['tf']) {
     await dynamicScript(`https://unpkg.com/@tensorflow/tfjs@${TF_VERSION}/dist/tf.min.js`);
   }
   return window['tf'];
 };
-
-export {tf};

--- a/src/runtime/storageNG/storage-proxy.ts
+++ b/src/runtime/storageNG/storage-proxy.ts
@@ -9,9 +9,9 @@
  */
 
 import {assert} from '../../platform/assert-web.js';
-import {CRDTChange, CRDTConsumerType, CRDTData, CRDTError, CRDTModel, CRDTOperation, CRDTTypeRecord, VersionMap} from '../crdt/crdt';
-import {Handle} from './handle';
-import {ActiveStore, ProxyMessage, ProxyMessageType} from './store';
+import {CRDTChange, CRDTConsumerType, CRDTData, CRDTError, CRDTModel, CRDTOperation, CRDTTypeRecord, VersionMap} from '../crdt/crdt.js';
+import {Handle} from './handle.js';
+import {ActiveStore, ProxyMessage, ProxyMessageType} from './store.js';
 
 /**
  * TODO: describe this class.

--- a/src/runtime/storageNG/tests/storage-proxy-test.ts
+++ b/src/runtime/storageNG/tests/storage-proxy-test.ts
@@ -9,14 +9,14 @@
  */
 
 import {assert} from '../../../platform/chai-web.js';
-import {CRDTOperation, CRDTTypeRecord} from '../../crdt/crdt';
-import {CRDTSingleton, CRDTSingletonTypeRecord, SingletonOperation, SingletonOpTypes} from '../../crdt/crdt-singleton';
-import {Particle} from '../../particle';
-import {Exists} from '../drivers/driver-factory';
-import {Handle} from '../handle';
-import {StorageKey} from '../storage-key';
-import {StorageProxy} from '../storage-proxy';
-import {ActiveStore, StorageMode, ProxyCallback, ProxyMessage, ProxyMessageType} from '../store';
+import {CRDTOperation, CRDTTypeRecord} from '../../crdt/crdt.js';
+import {CRDTSingleton, CRDTSingletonTypeRecord, SingletonOperation, SingletonOpTypes} from '../../crdt/crdt-singleton.js';
+import {Particle} from '../../particle.js';
+import {Exists} from '../drivers/driver-factory.js';
+import {Handle} from '../handle.js';
+import {StorageKey} from '../storage-key.js';
+import {StorageProxy} from '../storage-proxy.js';
+import {ActiveStore, StorageMode, ProxyCallback, ProxyMessage, ProxyMessageType} from '../store.js';
 
 
 export class MockStore<T extends CRDTTypeRecord> extends ActiveStore<T> {

--- a/src/runtime/storageNG/tests/store-sequence-test.ts
+++ b/src/runtime/storageNG/tests/store-sequence-test.ts
@@ -137,7 +137,7 @@ describe('Store Flow', async () => {
   // Tests 3 operation updates happening synchronously with 2 model updates from the driver
   it('applies 3 operations and 2 models simultaneously', async function() {    
 
-    this.timeout(5000);
+    this.timeout(6000);
 
     const sequenceTest = new SequenceTest<ActiveStore<CRDTCountTypeRecord>>();
     sequenceTest.setTestConstructor(async () => {

--- a/src/services/mobilenet.ts
+++ b/src/services/mobilenet.ts
@@ -1,0 +1,10 @@
+import {dynamicScript} from '../platform/dynamic-script-web.js';
+
+const modelUrl = 'https://cdn.jsdelivr.net/npm/@tensorflow-models/mobilenet@1.0.0';
+
+export const requireMobilenet = async () => {
+  if (!window['mobilenet']) {
+    await dynamicScript(modelUrl);
+  }
+  return window['mobilenet'];
+}

--- a/src/services/resource-manager.ts
+++ b/src/services/resource-manager.ts
@@ -52,6 +52,11 @@ export class ResourceManager {
    * @param r An identifier or reference to the value to be cleaned up.
    */
   static dispose(r: Reference): void {
+    const obj = this.references[r];
+
+    if (obj['dispose']) {
+      obj.dispose();
+    }
     delete this.references[r];
   }
 }

--- a/src/services/tfjs-mobilenet-service.ts
+++ b/src/services/tfjs-mobilenet-service.ts
@@ -13,7 +13,8 @@ import {Reference, ResourceManager} from './resource-manager.js';
 import {logFactory} from '../platform/log-web.js';
 import {Services} from '../runtime/services.js';
 import {loadImage} from '../platform/image-web.js';
-import {requireTf} from '../platform/tf-web.js';
+import {requireTf, tf} from '../platform/tf-web.js';
+import {ClassificationPrediction} from './tfjs-service.js';
 
 const log = logFactory('tfjs-mobilenet-service');
 
@@ -34,17 +35,12 @@ interface MobilenetParams {
 }
 
 /** @see https://github.com/tensorflow/tfjs-models/tree/master/mobilenet#making-a-classification */
-type MobilenetImageInput = ImageData | HTMLImageElement | HTMLCanvasElement | HTMLVideoElement; // | tf.Tensor3D;
+type MobilenetImageInput = ImageData | HTMLImageElement | HTMLCanvasElement | HTMLVideoElement | tf.Tensor3D;
 
 interface ImageInferenceParams {
   model: Reference;
   image?: MobilenetImageInput;
   imageUrl?: string;
-}
-
-interface ClassificationPrediction {
-  className: string;
-  probability: number;
 }
 
 interface Classifier {

--- a/src/services/tfjs-mobilenet-service.ts
+++ b/src/services/tfjs-mobilenet-service.ts
@@ -8,18 +8,21 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {dynamicScript} from '../platform/dynamic-script-web.js';
 import {Reference, ResourceManager} from './resource-manager.js';
 import {logFactory} from '../platform/log-web.js';
 import {Services} from '../runtime/services.js';
 import {loadImage} from '../platform/image-web.js';
-import {requireTf, tf} from '../platform/tf-web.js';
 import {ClassificationPrediction} from './tfjs-service.js';
+import {requireMobilenet} from './mobilenet.js';
+
+// TODO(sjmiles): figure out a way to make the next two imports into one
+
+// for types only, elided by TSC (make sure not to use Tf as a value!)
+import * as Tf from '@tensorflow/tfjs';
+// for actual code
+import {requireTf} from '../platform/tf-web.js';
 
 const log = logFactory('tfjs-mobilenet-service');
-
-const modelUrl = 'https://cdn.jsdelivr.net/npm/@tensorflow-models/mobilenet@1.0.0';
-
 
 /**
  * A tuple that determines the type and structure of MobileNet
@@ -35,7 +38,7 @@ interface MobilenetParams {
 }
 
 /** @see https://github.com/tensorflow/tfjs-models/tree/master/mobilenet#making-a-classification */
-type MobilenetImageInput = ImageData | HTMLImageElement | HTMLCanvasElement | HTMLVideoElement | tf.Tensor3D;
+type MobilenetImageInput = ImageData | HTMLImageElement | HTMLCanvasElement | HTMLVideoElement | Tf.Tensor3D;
 
 interface ImageInferenceParams {
   model: Reference;
@@ -71,11 +74,12 @@ interface MobilenetEmbedding extends MobilenetParams {
  */
 const load = async ({version = 1, alpha = 1.0}: MobilenetParams): Promise<Reference> => {
   log('Loading tfjs...');
-  const tf = await requireTf();
+  await requireTf();
   log('Loading MobileNet...');
-  await dynamicScript(modelUrl);
-  const model = await window['mobilenet'].load(version, alpha);
-  log('MobileNet Loaded.');
+  const mobilenet = await requireMobilenet();
+  log('Loading model...');
+  const model = await mobilenet.load(version, alpha);
+  log('Model loaded.');
   model.version = version;
   model.alpha = alpha;
   return ResourceManager.ref(model);
@@ -91,21 +95,14 @@ const load = async ({version = 1, alpha = 1.0}: MobilenetParams): Promise<Refere
  * @return A list (or single item) of `ClassificationPrediction`s, which are "label, confidence" tuples.
  */
 const classify = async ({model, image, imageUrl, topK = 1}: ImageInferenceParams & {topK: number}): Promise<ClassificationPrediction[] | ClassificationPrediction> => {
-  log('Loading tfjs...');
-  const tf = await requireTf();
-
   const model_: Classifier = ResourceManager.deref(model) as Classifier;
-
   const img = await getImage(image, imageUrl);
-
   log('classifying...');
   const predictions = await model_.classify(img, topK);
   log('classified.');
-
   if (topK === 1) {
     return predictions.shift();
   }
-
   return predictions;
 };
 
@@ -119,9 +116,6 @@ const classify = async ({model, image, imageUrl, topK = 1}: ImageInferenceParams
  * @see MobilenetEmbedding
  */
 const extractEmbeddings = async ({model, image, imageUrl}: ImageInferenceParams): Promise<MobilenetEmbedding> => {
-  log('Loading tfjs...');
-  const tf = await requireTf();
-
   const model_ = ResourceManager.deref(model) as MobilenetClassifier;
   const img = await getImage(image, imageUrl);
 
@@ -131,7 +125,6 @@ const extractEmbeddings = async ({model, image, imageUrl}: ImageInferenceParams)
 
   return {version: model_.version, alpha: model_.alpha, feature: inference};
 };
-
 
 /** Clean up model resources. */
 const dispose = ({reference}) => ResourceManager.dispose(reference);

--- a/src/services/tfjs-service.ts
+++ b/src/services/tfjs-service.ts
@@ -9,16 +9,294 @@
  */
 import {Reference, ResourceManager as rmgr} from './resource-manager.js';
 import {logFactory} from '../platform/log-web.js';
-import {Services} from '../runtime/services.js';
+import {Service, Services} from '../runtime/services.js';
 import {requireTf} from '../platform/tf-web.js';
+import {loadImage} from '../platform/image-web.js';
+import {tf} from '../platform/tf-node.js';
 
 const log = logFactory('tfjs-service');
-// Map some TF API to a Service
-const dispose = ({reference}) => rmgr.dispose(reference);
 
-// TODO(alxr) Will add generic ML model service functions in #3094
+type TfTensor = tf.Tensor | tf.Tensor[] | tf.NamedTensorMap;
 
-Services.register('tfjs', {
-  dispose,
+export interface ClassificationPrediction {
+  className: string;
+  probability: number;
+}
+
+abstract class TfModel implements Service {
+
+  public abstract async load({modelUrl, options}): Promise<Reference>;
+
+  /**
+   * Execute inference for the input tensors.
+   *
+   * @param {Reference} model An inference model
+   * @param {Reference} inputs The input tensor
+   * @param {tf.ModelPredictConfig} config Control verbosity and batchSize.
+   */
+  public async predict({model, inputs, config}): Promise<Reference> {
+    const tf = await requireTf();
+
+    log('Referencing model and input...');
+    const model_  = rmgr.deref(model) as tf.InferenceModel;
+    const inputs_ = rmgr.deref(inputs) as TfTensor;
+
+    log('Predicting...');
+    const yHat = await model_.predict(inputs_, config) as TfTensor;
+
+    log('Predicted.');
+    return rmgr.ref(yHat);
+  }
+
+  /**
+   * Load the model weights eagerly, so subsequent calls to `predict` will be fast.
+   *
+   * @param {Reference} model An inference model
+   * @see https://www.tensorflow.org/js/guide/platform_environment#shader_compilation_texture_uploads
+   */
+  public async warmUp({model}): Promise<void> {
+    const tf = await requireTf();
+
+    log('Warming up model...');
+    const model_  = rmgr.deref(model) as tf.InferenceModel;
+
+    const zeros = model_.inputs
+      .map(i => i.shape ? i.shape : [])
+      .map((sh) => sh.map(x => Math.abs(x)))
+      .map((sh) => tf.zeros(sh || [1]));
+
+    const zeroInput = zeros.length === 1 ? zeros[0] : zeros;
+
+    const result = await model_.predict(zeroInput, {}) as tf.Tensor;
+    result.dispose();
+
+    log('Model warm.');
+  }
+
+  /** Clean up resources */
+  public dispose({reference}): void {
+    rmgr.dispose(reference);
+  }
+}
+
+
+class GraphModel extends TfModel {
+  /**
+   * Load a graph model given a URL to the model definition.
+   *
+   * @param {Reference} modelUrl the url that loads the model.
+   * @param {tf.io.LoadOptions} options Options for the HTTP request, which allows to send credentials
+   *  and custom headers.
+   * @return {Reference} A reference to the in-memory model.
+   */
+  public async load({modelUrl, options}): Promise<Reference> {
+    const tf = await requireTf();
+
+    log('Loading model...');
+    const model = await tf.loadGraphModel(modelUrl, options);
+
+    log('Model loaded.');
+    return rmgr.ref(model);
+  }
+
+  /**
+   * Properly clean up the resource used for the graph model.
+   *
+   * @param {Reference} reference to a graph model.
+   */
+  public dispose({reference}): void {
+    const model_ = rmgr.deref(reference) as tf.GraphModel;
+    model_.dispose();
+    super.dispose(reference);
+  }
+
+}
+
+class LayersModel extends TfModel {
+  /**
+   * Load a layers model given a URL to the model definition.
+   *
+   * @param {Reference} modelUrl the url that loads the model.
+   * @param {tf.io.LoadOptions} options Options for the HTTP request, which allows to send credentials
+   *  and custom headers.
+   * @return {Reference} A reference to the in-memory model.
+   */
+  async load({modelUrl, options}): Promise<Reference> {
+    const tf = await requireTf();
+
+    log('Loading model...');
+    const model = await tf.loadLayersModel(modelUrl, options);
+
+    log('Model loaded.');
+    return rmgr.ref(model);
+  }
+}
+
+/**
+ * Converts a URL of an image into a 3D tensor.
+ *
+ * @param {string} imageUrl image to convert
+ * @return {Reference} The tf.Tensor3D representation of the image.
+ * @see {tf.browser.fromPixels()}
+ */
+const imageToTensor = async ({imageUrl}): Promise<Reference> => {
+  const tf = await requireTf();
+
+  log('Converting image to tensor...');
+  const imgElem = await loadImage(imageUrl);
+  const imgTensor = await tf.browser.fromPixels(imgElem, 3) as tf.Tensor3D;
+
+  log('Image converted.');
+  return rmgr.ref(imgTensor);
+};
+
+
+/**
+ * Given the range of possible values, ensure all elements fall between -1 and 1.
+ *
+ * @param {Reference} input Tensor to normalize.
+ * @param {[number, number]} range [hi, low] tuple. Default: [0, 255].
+ * @return {Reference} A new tensor with values normalized.
+ */
+const normalize = async ({input, range=[0, 255]}): Promise<Reference> => {
+  const tf = await requireTf();
+
+  log('Normalizing...');
+  const input_ = rmgr.deref(input) as tf.Tensor;
+
+  const max_ = Math.max(...range);
+  const min_ = Math.min(...range);
+  const mid = (max_ - min_) / 2 + min_;
+
+  const normOffset = tf.scalar(mid);
+
+  const normalized = input_.toFloat()
+    .sub(normOffset)
+    .div(normOffset) as tf.Tensor3D;
+
+  log('Normalized.');
+  return rmgr.ref(normalized);
+};
+
+/**
+ * Transform the shape of the input tensor into a new shape, preserving the number of elements.
+ *
+ * @param {Reference} input The tensor to transform.
+ * @param {number[]} newShape Desired shape. Must specify `newShape` or `shape`.
+ * @param {number[]} shape Desired shape. Must specify `newShape` or `shape`.
+ * @return {Reference} The reshaped tensor.
+ */
+const reshape = async ({input, newShape, shape}): Promise<Reference> => {
+  const tf = await requireTf();
+
+  log('Reshaping...');
+  const input_ = rmgr.deref(input);
+  const resized = await tf.reshape(input_, newShape || shape);
+
+  log('Reshaped.');
+  return rmgr.ref(resized);
+};
+
+/**
+ * Expand (increase) the number of dimensions of a tensor by one.
+ *
+ * @param {Reference} input Tensor to transform. Must specify `input` or `x`.
+ * @param {Reference} x Tensor to transform. Must specify `input` or `x`.
+ * @param {number} axis Integer value, dimension to expand on. Default: 0
+ * @return {Reference} A tensor with expanded rank.
+ */
+const expandDims = async ({input, x, axis = 0}): Promise<Reference> => {
+  const tf = await requireTf();
+
+  log('Expanding dimensions...');
+  const input_ = rmgr.deref(input || x);
+  const expanded = tf.expandDims(input_, axis);
+
+  log('Dimensions expanded.');
+  return rmgr.ref(expanded);
+};
+
+/**
+ * Use bilinear-interpolation to resize a batch of images.
+ *
+ * @param {Reference} images A batch of images to resize of rank 4 or 3. If rank 3, a batch of 1 is assumed.
+ * @param {[number, number]} size The new shape `[newHeight, newWidth]` to resize the image to.
+ * @param {boolean} alignCorners  Defaults to False. If true, rescale input by (new_height - 1) / (height - 1),
+ *  which exactly aligns the 4 corners of images and resized images. If false, rescale by new_height / height.
+ *  Treat similarly the width dimension. Optional
+ * @return {Reference} Images with a new shape.
+ */
+const resizeBilinear = async ({images, size, alignCorners}): Promise<Reference> => {
+  const tf = await requireTf();
+
+  log('Bilinear resizing image(s)...');
+  const images_ = rmgr.deref(images);
+  const resized = await tf.image.resizeBilinear(images_, size, alignCorners);
+  log('Resized image(s).');
+
+  return rmgr.ref(resized);
+};
+
+/**
+ * Return a ranked list (of size K) of classes with their associated probabilities.
+ *
+ * @param {Reference} input Prediction tensor. Must specify either `input`, `y`, or `yHat`.
+ * @param {Reference} y Prediction tensor. Must specify either `input`, `y`, or `yHat`.
+ * @param {Reference} yHat Prediction tensor. Must specify either `input`, `y`, or `yHat`.
+ * @param {string[]} labels A mapping between label index and value.
+ * @param {number} topK The total number of labels to return
+ * @return {ClassificationPrediction[]} A list of predictions, complete with `className` and `probability`.
+ */
+const getTopKClasses = async ({input, y, yHat, labels, topK=3}): Promise<ClassificationPrediction[]> => {
+  log('Getting top K classes...');
+  const input_ = rmgr.deref(input || y || yHat) as tf.Tensor2D;
+
+  const softmax = input_.softmax();
+  const values = await softmax.data();
+  softmax.dispose();
+
+  const valuesAndIndices = [];
+  for (let i = 0; i < values.length; i++) {
+    valuesAndIndices.push({value: values[i], index: i});
+  }
+  valuesAndIndices.sort((a, b) => {
+    return b.value - a.value;
+  });
+  const topkValues = new Float32Array(topK);
+  const topkIndices = new Int32Array(topK);
+  for (let i = 0; i < topK; i++) {
+    topkValues[i] = valuesAndIndices[i].value;
+    topkIndices[i] = valuesAndIndices[i].index;
+  }
+
+  const topClassesAndProbs = [];
+  for (let i = 0; i < topkIndices.length; i++) {
+    topClassesAndProbs.push({
+      className: labels[topkIndices[i]],
+      probability: topkValues[i]
+    });
+  }
+  log('found top K classes.');
+  return topClassesAndProbs;
+};
+
+
+Services.register('graph-model', new GraphModel());
+Services.register('layer-model', new LayersModel());
+
+Services.register('preprocess', {
+  normalize,
+  reshape,
+  expandDims,
 });
+
+Services.register('postprocess', {
+  getTopKClasses,
+});
+
+Services.register('tf-image', {
+  resizeBilinear,
+  imageToTensor,
+});
+
 

--- a/src/services/tfjs-service.ts
+++ b/src/services/tfjs-service.ts
@@ -12,7 +12,7 @@ import {logFactory} from '../platform/log-web.js';
 import {Service, Services} from '../runtime/services.js';
 import {requireTf} from '../platform/tf-web.js';
 import {loadImage} from '../platform/image-web.js';
-import {tf} from '../platform/tf-node.js';
+import {tf} from '../platform/tf-web.js';
 
 const log = logFactory('tfjs-service');
 


### PR DESCRIPTION
Mostly the concept is that if one does:
`import * as Tf from '@tensorflow/tfjs';`
and are careful not to use Tf as a **value**, then TSC will use that import only for types and will elide it from the compiled output (the js).

Then one can do:
`import {requireTf} from '../platform/tf-web.js';
and use `requireTf()` to acquire actual implementation.

This way we can have our types without additional (real) dependencies. We are also free to load the implementation on demand.
