### PR TITLE
Scott's Suggested Mods

### DIFF
--- a/particles/Services/particles/js/MobileNet.js
+++ b/particles/Services/particles/js/MobileNet.js
@@ -45,7 +45,7 @@ defineParticle(({DomParticle, log, html, resolver}) => {
       response = response || {label: '<working>', probability: '<working>'};
       return {
         label: response.className,
-        probability: response.probability.toFixed(4),
+        probability: response.probability,
         imageUrl: url
       };
     }

--- a/src/platform/tf-web.ts
+++ b/src/platform/tf-web.ts
@@ -9,18 +9,14 @@
  */
 
 import {dynamicScript} from './dynamic-script-web.js';
-import * as tf from '../../node_modules/@tensorflow/tfjs-core/dist/tf-core.js';
 
 const TF_VERSION = '1.1.2';
 
 /** Dynamically loads and returns the `tfjs` module. */
 export const requireTf = async () => {
-
   // Assume tf.data is not required for most dependencies
-  if (!window['tf'] || !window['tf']['version_core'] || !window['tf']['version_layers'] || !window['tf']['version_converter']) {
+  if (!window['tf']) {
     await dynamicScript(`https://unpkg.com/@tensorflow/tfjs@${TF_VERSION}/dist/tf.min.js`);
   }
   return window['tf'];
 };
-
-export {tf};

--- a/src/services/mobilenet.ts
+++ b/src/services/mobilenet.ts
@@ -1,0 +1,10 @@
+import {dynamicScript} from '../platform/dynamic-script-web.js';
+
+const modelUrl = 'https://cdn.jsdelivr.net/npm/@tensorflow-models/mobilenet@1.0.0';
+
+export const requireMobilenet = async () => {
+  if (!window['mobilenet']) {
+    await dynamicScript(modelUrl);
+  }
+  return window['mobilenet'];
+}

--- a/src/services/tfjs-mobilenet-service.ts
+++ b/src/services/tfjs-mobilenet-service.ts
@@ -8,18 +8,21 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {dynamicScript} from '../platform/dynamic-script-web.js';
 import {Reference, ResourceManager} from './resource-manager.js';
 import {logFactory} from '../platform/log-web.js';
 import {Services} from '../runtime/services.js';
 import {loadImage} from '../platform/image-web.js';
-import {requireTf, tf} from '../platform/tf-web.js';
 import {ClassificationPrediction} from './tfjs-service.js';
+import {requireMobilenet} from './mobilenet.js';
+
+// TODO(sjmiles): figure out a way to make the next two imports into one
+
+// for types only, elided by TSC (make sure not to use Tf as a value!)
+import * as Tf from '@tensorflow/tfjs';
+// for actual code
+import {requireTf} from '../platform/tf-web.js';
 
 const log = logFactory('tfjs-mobilenet-service');
-
-const modelUrl = 'https://cdn.jsdelivr.net/npm/@tensorflow-models/mobilenet@1.0.0';
-
 
 /**
  * A tuple that determines the type and structure of MobileNet
@@ -35,7 +38,7 @@ interface MobilenetParams {
 }
 
 /** @see https://github.com/tensorflow/tfjs-models/tree/master/mobilenet#making-a-classification */
-type MobilenetImageInput = ImageData | HTMLImageElement | HTMLCanvasElement | HTMLVideoElement | tf.Tensor3D;
+type MobilenetImageInput = ImageData | HTMLImageElement | HTMLCanvasElement | HTMLVideoElement | Tf.Tensor3D;
 
 interface ImageInferenceParams {
   model: Reference;
@@ -71,11 +74,12 @@ interface MobilenetEmbedding extends MobilenetParams {
  */
 const load = async ({version = 1, alpha = 1.0}: MobilenetParams): Promise<Reference> => {
   log('Loading tfjs...');
-  const tf = await requireTf();
+  await requireTf();
   log('Loading MobileNet...');
-  await dynamicScript(modelUrl);
-  const model = await window['mobilenet'].load(version, alpha);
-  log('MobileNet Loaded.');
+  const mobilenet = await requireMobilenet();
+  log('Loading model...');
+  const model = await mobilenet.load(version, alpha);
+  log('Model loaded.');
   model.version = version;
   model.alpha = alpha;
   return ResourceManager.ref(model);
@@ -91,21 +95,14 @@ const load = async ({version = 1, alpha = 1.0}: MobilenetParams): Promise<Refere
  * @return A list (or single item) of `ClassificationPrediction`s, which are "label, confidence" tuples.
  */
 const classify = async ({model, image, imageUrl, topK = 1}: ImageInferenceParams & {topK: number}): Promise<ClassificationPrediction[] | ClassificationPrediction> => {
-  log('Loading tfjs...');
-  const tf = await requireTf();
-
   const model_: Classifier = ResourceManager.deref(model) as Classifier;
-
   const img = await getImage(image, imageUrl);
-
   log('classifying...');
   const predictions = await model_.classify(img, topK);
   log('classified.');
-
   if (topK === 1) {
     return predictions.shift();
   }
-
   return predictions;
 };
 
@@ -119,9 +116,6 @@ const classify = async ({model, image, imageUrl, topK = 1}: ImageInferenceParams
  * @see MobilenetEmbedding
  */
 const extractEmbeddings = async ({model, image, imageUrl}: ImageInferenceParams): Promise<MobilenetEmbedding> => {
-  log('Loading tfjs...');
-  const tf = await requireTf();
-
   const model_ = ResourceManager.deref(model) as MobilenetClassifier;
   const img = await getImage(image, imageUrl);
 
@@ -131,7 +125,6 @@ const extractEmbeddings = async ({model, image, imageUrl}: ImageInferenceParams)
 
   return {version: model_.version, alpha: model_.alpha, feature: inference};
 };
-
 
 /** Clean up model resources. */
 const dispose = ({reference}) => ResourceManager.dispose(reference);


### PR DESCRIPTION
Mostly the concept is that if one does:
`import * as Tf from '@tensorflow/tfjs';`
and are careful not to use Tf as a **value**, then TSC will use that import only for types and will elide it from the compiled output (the js).

Then one can do:
`import {requireTf} from '../platform/tf-web.js';
and use `requireTf()` to acquire actual implementation.

This way we can have our types without additional (real) dependencies. We are also free to load the implementation on demand.
